### PR TITLE
Better heuristic for detecting branch and repository button menus.

### DIFF
--- a/GitHubA11yFixes.user.js
+++ b/GitHubA11yFixes.user.js
@@ -73,7 +73,7 @@ function onNodeAdded(target) {
 	} else if (res[1] == "compare") {
 		// Branch selector buttons.
 		// These have an aria-label which masks the name of the branch, so kill it.
-		for (elem of target.querySelectorAll("button.branch"))
+		for (elem of target.querySelectorAll("button.js-menu-target"))
 			elem.removeAttribute("aria-label");
 	}
 	if (["pull", "commit"].indexOf(res[1]) >= 0 && res[2]) {


### PR DESCRIPTION
compare view: We previously were using a heuristic that matched on button.branch. We can match on button.js-menu-target and kill two birds with one stone (I.E. the choose a fork button brings up two new menus that had the same bug referenced on line 75).
