### PR TITLE
Slack: Remove extra a11y attributes from `close_flexpane` button

### DIFF
--- a/SlackA11yFixes.user.js
+++ b/SlackA11yFixes.user.js
@@ -19,12 +19,6 @@ function initial() {
 	// Same for the unread messages status, which appears below in DOM order but earlier visually.
 	if (elem = document.querySelector("#messages_container"))
 		elem.setAttribute("aria-owns", "messages_unread_status threads_view_banner monkey_scroll_wrapper_for_msgs_scroller_div monkey_scroll_wrapper_for_threads_msgs_scroller_div");
-	// Make close link for about channel pane accessible.
-	for (elem of document.querySelectorAll(".close_flexpane")) {
-		elem.setAttribute("role", "button");
-		// The content is a private use Unicode character. Use the title as the name.
-		elem.setAttribute("aria-label", elem.getAttribute("title"));
-	}
 }
 
 // Make the starred status accessible.

--- a/readme.md
+++ b/readme.md
@@ -71,7 +71,6 @@ It does the following:
 - Makes options for each message (Start a thread, Share message, etc.) accessible.
  To access these, move the mouse to the text of a message.
  They then appear above the author's name as buttons.
-- Makes the close link for the about channel pane accessible.
 - Makes day separators in the message history and the about channel pane heading accessible as headings.
 - Reports incoming messages automatically (using a live region).
 - Hides an editable area which isn't shown visually.


### PR DESCRIPTION
Based on the `close_flexpane` button markup on Slack now, we have:

`<button class="btn_basic close_flexpane" aria-label="Close Right Sidebar" title="Close Right Sidebar" type="button">`

- Since this element is a `<button>`, the `role` attribute is no longer necessary
- Since this element has an `aria-label` attribute, we no longer need to add one
- Update "Slack Accessibility Fixes" in README to reflect the above changes