### PR TITLE
Make the github notifications accessible.

### DIFF
--- a/GitHubA11yFixes.user.js
+++ b/GitHubA11yFixes.user.js
@@ -3,7 +3,7 @@
 // @namespace      http://axSgrease.nvaccess.org/
 // @description    Improves the accessibility of GitHub.
 // @author         James Teh <jamie@nvaccess.org>
-// @copyright 2015-2016 NV Access Limited
+// @copyright 2015-2018 NV Access Limited
 // @license GNU General Public License version 2.0
 // @version        2016.1
 // @grant GM_log

--- a/GitHubA11yFixes.user.js
+++ b/GitHubA11yFixes.user.js
@@ -15,6 +15,25 @@ function makeHeading(elem, level) {
 	elem.setAttribute("aria-level", level);
 }
 
+var idCounter = 0;
+// Get a node's id. If it doesn't have one, make and set one first.
+function setAriaIdIfNecessary(elem) {
+	if (elem.id) {
+		return elem.id;
+	}
+	console.log(elem);
+	elem.setAttribute("id", "axsg-" + idCounter++);
+	return elem.id;
+}
+
+function makeElementOwn(parentElement, listOfNodes){
+	ids = [];
+	for(let node of listOfNodes){
+		ids.push(setAriaIdIfNecessary(node));
+	}
+	parentElement.setAttribute("aria-owns", ids.join(" "));
+}
+
 function onSelectMenuItemChanged(target) {
 	target.setAttribute("aria-checked", target.classList.contains("selected") ? "true" : "false");
 }
@@ -39,70 +58,9 @@ function onDropdownChanged(target) {
 	}
 }
 
-// Used when we need to generate ids for ARIA.
-var idCounter = 0;
 
-function onNodeAdded(target) {
+function doGlobal(target){
 	var elem;
-	var res = document.location.href.match(/github.com\/[^\/]+\/[^\/]+(?:\/([^\/?]+))?(?:\/([^\/?]+))?(?:\/([^\/?]+))?(?:\/([^\/?]+))?/);
-	// res[1] to res[4] are 4 path components of the URL after the project.
-	// res[1] will be "issues", "pull", "commit", etc.
-	// Empty path components will be undefined.
-	if (["issues", "pull", "commit"].indexOf(res[1]) >= 0 && res[2]) {
-		// Issue, pull request or commit.
-		// Comment headers.
-		for (elem of target.querySelectorAll(".timeline-comment-header-text, .discussion-item-header"))
-			makeHeading(elem, 3);
-	}
-	if (res[1] == "commits" || (res[1] == "pull" && res[3] == "commits" && !res[4])) {
-		// Commit listing.
-		// Commit group headers.
-		for (elem of target.querySelectorAll(".commit-group-title"))
-			makeHeading(elem, 2);
-	} else if ((res[1] == "commit" && res[2]) || (res[1] == "pull" && res[3] == "commits" && res[4])) {
-		// Single commit.
-		if (elem = target.querySelector(".commit-title"))
-			makeHeading(elem, 2);
-	} else if (res[1] == "blob") {
-		// Viewing a single file.
-		// Ensure the table never gets treated as a layout table.
-		if (elem = target.querySelector(".js-file-line-container"))
-			elem.setAttribute("role", "table");
-	} else if (res[1] == "tree" || !res[1]) {
-		// A file list is on this page.
-		// Ensure the table never gets treated as a layout table.
-		if (elem = target.querySelector(".files"))
-			elem.setAttribute("role", "table");
-	} else if (res[1] == "compare") {
-		// Branch selector buttons.
-		// These have an aria-label which masks the name of the branch, so kill it.
-		for (elem of target.querySelectorAll("button.select-menu-button"))
-			elem.removeAttribute("aria-label");
-	}
-	if (["pull", "commit"].indexOf(res[1]) >= 0 && res[2]) {
-		// Pull request or commit.
-		// Header for each changed file.
-		for (elem of target.querySelectorAll(".file-info"))
-			makeHeading(elem, 2);
-		// Lines of code which can be commented on.
-		for (elem of target.querySelectorAll(".add-line-comment")) {
-			// Put the comment button after the code instead of before.
-			// elem is the Add line comment button.
-			elem.setAttribute("id", "axsg-alc" + idCounter);
-			// nextElementSibling is the actual code.
-			elem.nextElementSibling.setAttribute("id", "axsg-l" + idCounter);
-			// Reorder children using aria-owns.
-			elem.parentNode.setAttribute("aria-owns", "axsg-l" + idCounter + " axsg-alc" + idCounter);
-			++idCounter;
-		}
-		// Make sure diff tables never get treated as a layout table.
-		for (elem of target.querySelectorAll(".diff-table"))
-			elem.setAttribute("role", "table");
-		// Review comment headers.
-		for (elem of target.querySelectorAll(".review-comment-contents > strong"))
-			makeHeading(elem, 3);
-	}
-
 	// Site-wide stuff.
 	// Checkable menu items; e.g. in watch and labels pop-ups.
 	if (target.classList.contains("select-menu-item")) {
@@ -165,6 +123,85 @@ function onNodeAdded(target) {
 	}
 }
 
+function onNodeAdded(target) {
+	var elem;
+	if(document.location.pathname.match(/\/(?:[^\/]+\/[^\/]+\/)?notifications\/?/)){
+		// Notifications page.
+		//First, make sure the h3 with the repo becomes an h2, so we can set the notifications for that repos as an h3.
+		for(elem of target.querySelectorAll(".notifications-repo-link"))
+			makeHeading(elem.parentNode, 2);
+		//Now, set the link marking each notification as an h3.
+		for(elem of target.querySelectorAll(".list-group-item-link")){
+			// Make the parent span a heading, but aria-owns the image to the end of this heading for niceity.
+			makeElementOwn(elem.parentNode, [elem, elem.previousElementSibling]);
+			makeHeading(elem.parentNode, 3);
+		}
+		//firefox   overrides title as if it was aria-label. Remove title here because it might mask the issue contents or other info.
+		//This unfortunately breaks visual content, but it doesn't really matter.
+		elem.removeAttribute("title"); 
+		return;
+	}
+	var res = document.location.pathname.match(/\/[^\/]+\/[^\/]+(?:\/([^\/?]+))?(?:\/([^\/?]+))?(?:\/([^\/?]+))?(?:\/([^\/?]+))?/);
+	//In some cases (main page) res[1] is null. Thou shal not pass.
+	if(res[1] === null)
+		return;
+	// res[1] to res[4] are 4 path components of the URL after the project.
+	// res[1] will be "issues", "pull", "commit", etc.
+	// Empty path components will be undefined.
+	if (["issues", "pull", "commit"].indexOf(res[1]) >= 0 && res[2]) {
+		// Issue, pull request or commit.
+		// Comment headers.
+		for (elem of target.querySelectorAll(".timeline-comment-header-text, .discussion-item-header"))
+			makeHeading(elem, 3);
+	}
+	if (res[1] == "commits" || (res[1] == "pull" && res[3] == "commits" && !res[4])) {
+		// Commit listing.
+		// Commit group headers.
+		for (elem of target.querySelectorAll(".commit-group-title"))
+			makeHeading(elem, 2);
+	} else if ((res[1] == "commit" && res[2]) || (res[1] == "pull" && res[3] == "commits" && res[4])) {
+		// Single commit.
+		if (elem = target.querySelector(".commit-title"))
+			makeHeading(elem, 2);
+	} else if (res[1] == "blob") {
+		// Viewing a single file.
+		// Ensure the table never gets treated as a layout table.
+		if (elem = target.querySelector(".js-file-line-container"))
+			elem.setAttribute("role", "table");
+	} else if (res[1] == "tree" || !res[1]) {
+		// A file list is on this page.
+		// Ensure the table never gets treated as a layout table.
+		if (elem = target.querySelector(".files"))
+			elem.setAttribute("role", "table");
+	} else if (res[1] == "compare") {
+		// Branch selector buttons.
+		// These have an aria-label which masks the name of the branch, so kill it.
+		for (elem of target.querySelectorAll("button.select-menu-button"))
+			elem.removeAttribute("aria-label");
+	}
+	if (["pull", "commit"].indexOf(res[1]) >= 0 && res[2]) {
+		// Pull request or commit.
+		// Header for each changed file.
+		for (elem of target.querySelectorAll(".file-info"))
+			makeHeading(elem, 2);
+		// Lines of code which can be commented on.
+		for (elem of target.querySelectorAll(".add-line-comment")) {
+			// Put the comment button after the code instead of before.
+			// elem is the Add line comment button.
+			// nextElementSibling is the actual code.
+			// Reorder children using aria-owns.
+			makeElementOwn(elem.parentNode, [elem, elem.nextElementSibling]);
+		}
+		// Make sure diff tables never get treated as a layout table.
+		for (elem of target.querySelectorAll(".diff-table"))
+			elem.setAttribute("role", "table");
+		// Review comment headers.
+		for (elem of target.querySelectorAll(".review-comment-contents > strong"))
+			makeHeading(elem, 3);
+	}
+}
+
+
 function onClassModified(target) {
 	var classes = target.classList;
 	if (!classes)
@@ -186,6 +223,7 @@ var observer = new MutationObserver(function(mutations) {
 					if (node.nodeType != Node.ELEMENT_NODE)
 						continue;
 					onNodeAdded(node);
+					doGlobal(node);
 				}
 			} else if (mutation.type === "attributes") {
 				if (mutation.attributeName == "class")
@@ -201,3 +239,4 @@ observer.observe(document, {childList: true, attributes: true,
 	subtree: true, attributeFilter: ["class"]});
 
 onNodeAdded(document);
+doGlobal(document);

--- a/GitHubA11yFixes.user.js
+++ b/GitHubA11yFixes.user.js
@@ -17,7 +17,7 @@ function makeHeading(elem, level) {
 
 var idCounter = 0;
 // Get a node's id. If it doesn't have one, make and set one first.
-function setAriaIdIfNecessary(elem) {
+function getAriaId(elem) {
 	if (elem.id) {
 		return elem.id;
 	}
@@ -26,9 +26,9 @@ function setAriaIdIfNecessary(elem) {
 }
 
 function makeElementOwn(parentElement, listOfNodes){
-	ids = [];
+	let ids = [];
 for(let node of listOfNodes){
-		ids.push(setAriaIdIfNecessary(node));
+		ids.push(getAriaId(node));
 	}
 	parentElement.setAttribute("aria-owns", ids.join(" "));
 }
@@ -58,8 +58,79 @@ function onDropdownChanged(target) {
 }
 
 
-function doGlobal(target){
+function onNodeAdded(target) {
 	var elem;
+	if(document.location.pathname.match(/\/(?:[^\/]+\/[^\/]+\/)?notifications\/?/)){
+		// Notifications page.
+		//First, make sure the h3 with the repo becomes an h2, so we can set the notifications for that repos as an h3.
+		for(elem of target.querySelectorAll(".notifications-repo-link"))
+			makeHeading(elem.parentNode, 2);
+		//Now, set the link marking each notification as an h3.
+		for(elem of target.querySelectorAll(".list-group-item-link")){
+			// Make the parent span a heading, but aria-owns the image to the end of this heading for niceity.
+			makeElementOwn(elem.parentNode, [elem, elem.previousElementSibling]);
+			makeHeading(elem.parentNode, 3);
+		}
+		return;
+	}
+	var res = document.location.pathname.match(/\/[^\/]+\/[^\/]+(?:\/([^\/?]+))?(?:\/([^\/?]+))?(?:\/([^\/?]+))?(?:\/([^\/?]+))?/);
+	//In some cases (main page) res[1] is null. Thou shal not pass.
+	if(res[1] === null)
+		return;
+	// res[1] to res[4] are 4 path components of the URL after the project.
+	// res[1] will be "issues", "pull", "commit", etc.
+	// Empty path components will be undefined.
+	if (["issues", "pull", "commit"].indexOf(res[1]) >= 0 && res[2]) {
+		// Issue, pull request or commit.
+		// Comment headers.
+		for (elem of target.querySelectorAll(".timeline-comment-header-text, .discussion-item-header"))
+			makeHeading(elem, 3);
+	}
+	if (res[1] == "commits" || (res[1] == "pull" && res[3] == "commits" && !res[4])) {
+		// Commit listing.
+		// Commit group headers.
+		for (elem of target.querySelectorAll(".commit-group-title"))
+			makeHeading(elem, 2);
+	} else if ((res[1] == "commit" && res[2]) || (res[1] == "pull" && res[3] == "commits" && res[4])) {
+		// Single commit.
+		if (elem = target.querySelector(".commit-title"))
+			makeHeading(elem, 2);
+	} else if (res[1] == "blob") {
+		// Viewing a single file.
+		// Ensure the table never gets treated as a layout table.
+		if (elem = target.querySelector(".js-file-line-container"))
+			elem.setAttribute("role", "table");
+	} else if (res[1] == "tree" || !res[1]) {
+		// A file list is on this page.
+		// Ensure the table never gets treated as a layout table.
+		if (elem = target.querySelector(".files"))
+			elem.setAttribute("role", "table");
+	} else if (res[1] == "compare") {
+		// Branch selector buttons.
+		// These have an aria-label which masks the name of the branch, so kill it.
+		for (elem of target.querySelectorAll("button.select-menu-button"))
+			elem.removeAttribute("aria-label");
+	}
+	if (["pull", "commit"].indexOf(res[1]) >= 0 && res[2]) {
+		// Pull request or commit.
+		// Header for each changed file.
+		for (elem of target.querySelectorAll(".file-info"))
+			makeHeading(elem, 2);
+		// Lines of code which can be commented on.
+		for (elem of target.querySelectorAll(".add-line-comment")) {
+			// Put the comment button after the code instead of before.
+			// elem is the Add line comment button.
+			// nextElementSibling is the actual code.
+			// Reorder children using aria-owns.
+			makeElementOwn(elem.parentNode, [elem.nextElementSibling, elem]);
+		}
+		// Make sure diff tables never get treated as a layout table.
+		for (elem of target.querySelectorAll(".diff-table"))
+			elem.setAttribute("role", "table");
+		// Review comment headers.
+		for (elem of target.querySelectorAll(".review-comment-contents > strong"))
+			makeHeading(elem, 3);
+	}
 	// Site-wide stuff.
 	// Checkable menu items; e.g. in watch and labels pop-ups.
 	if (target.classList && target.classList.contains("select-menu-item")) {
@@ -123,84 +194,6 @@ function doGlobal(target){
 	}
 }
 
-function onNodeAdded(target) {
-	var elem;
-	if(document.location.pathname.match(/\/(?:[^\/]+\/[^\/]+\/)?notifications\/?/)){
-		// Notifications page.
-		//First, make sure the h3 with the repo becomes an h2, so we can set the notifications for that repos as an h3.
-		for(elem of target.querySelectorAll(".notifications-repo-link"))
-			makeHeading(elem.parentNode, 2);
-		//Now, set the link marking each notification as an h3.
-		for(elem of target.querySelectorAll(".list-group-item-link")){
-			// Make the parent span a heading, but aria-owns the image to the end of this heading for niceity.
-			makeElementOwn(elem.parentNode, [elem, elem.previousElementSibling]);
-			makeHeading(elem.parentNode, 3);
-		}
-		//firefox   overrides title as if it was aria-label. Remove title here because it might mask the issue contents or other info.
-		//This unfortunately breaks visual content, but it doesn't really matter.
-		elem.removeAttribute("title"); 
-		return;
-	}
-	var res = document.location.pathname.match(/\/[^\/]+\/[^\/]+(?:\/([^\/?]+))?(?:\/([^\/?]+))?(?:\/([^\/?]+))?(?:\/([^\/?]+))?/);
-	//In some cases (main page) res[1] is null. Thou shal not pass.
-	if(res[1] === null)
-		return;
-	// res[1] to res[4] are 4 path components of the URL after the project.
-	// res[1] will be "issues", "pull", "commit", etc.
-	// Empty path components will be undefined.
-	if (["issues", "pull", "commit"].indexOf(res[1]) >= 0 && res[2]) {
-		// Issue, pull request or commit.
-		// Comment headers.
-		for (elem of target.querySelectorAll(".timeline-comment-header-text, .discussion-item-header"))
-			makeHeading(elem, 3);
-	}
-	if (res[1] == "commits" || (res[1] == "pull" && res[3] == "commits" && !res[4])) {
-		// Commit listing.
-		// Commit group headers.
-		for (elem of target.querySelectorAll(".commit-group-title"))
-			makeHeading(elem, 2);
-	} else if ((res[1] == "commit" && res[2]) || (res[1] == "pull" && res[3] == "commits" && res[4])) {
-		// Single commit.
-		if (elem = target.querySelector(".commit-title"))
-			makeHeading(elem, 2);
-	} else if (res[1] == "blob") {
-		// Viewing a single file.
-		// Ensure the table never gets treated as a layout table.
-		if (elem = target.querySelector(".js-file-line-container"))
-			elem.setAttribute("role", "table");
-	} else if (res[1] == "tree" || !res[1]) {
-		// A file list is on this page.
-		// Ensure the table never gets treated as a layout table.
-		if (elem = target.querySelector(".files"))
-			elem.setAttribute("role", "table");
-	} else if (res[1] == "compare") {
-		// Branch selector buttons.
-		// These have an aria-label which masks the name of the branch, so kill it.
-		for (elem of target.querySelectorAll("button.select-menu-button"))
-			elem.removeAttribute("aria-label");
-	}
-	if (["pull", "commit"].indexOf(res[1]) >= 0 && res[2]) {
-		// Pull request or commit.
-		// Header for each changed file.
-		for (elem of target.querySelectorAll(".file-info"))
-			makeHeading(elem, 2);
-		// Lines of code which can be commented on.
-		for (elem of target.querySelectorAll(".add-line-comment")) {
-			// Put the comment button after the code instead of before.
-			// elem is the Add line comment button.
-			// nextElementSibling is the actual code.
-			// Reorder children using aria-owns.
-			makeElementOwn(elem.parentNode, [elem.nextElementSibling, elem]);
-		}
-		// Make sure diff tables never get treated as a layout table.
-		for (elem of target.querySelectorAll(".diff-table"))
-			elem.setAttribute("role", "table");
-		// Review comment headers.
-		for (elem of target.querySelectorAll(".review-comment-contents > strong"))
-			makeHeading(elem, 3);
-	}
-}
-
 
 function onClassModified(target) {
 	var classes = target.classList;
@@ -223,7 +216,6 @@ var observer = new MutationObserver(function(mutations) {
 					if (node.nodeType != Node.ELEMENT_NODE)
 						continue;
 					onNodeAdded(node);
-					doGlobal(node);
 				}
 			} else if (mutation.type === "attributes") {
 				if (mutation.attributeName == "class")
@@ -238,4 +230,3 @@ var observer = new MutationObserver(function(mutations) {
 observer.observe(document, {childList: true, attributes: true,
 	subtree: true, attributeFilter: ["class"]});
 onNodeAdded(document);
-doGlobal(document);

--- a/GitHubA11yFixes.user.js
+++ b/GitHubA11yFixes.user.js
@@ -21,14 +21,13 @@ function setAriaIdIfNecessary(elem) {
 	if (elem.id) {
 		return elem.id;
 	}
-	console.log(elem);
 	elem.setAttribute("id", "axsg-" + idCounter++);
 	return elem.id;
 }
 
 function makeElementOwn(parentElement, listOfNodes){
 	ids = [];
-	for(let node of listOfNodes){
+for(let node of listOfNodes){
 		ids.push(setAriaIdIfNecessary(node));
 	}
 	parentElement.setAttribute("aria-owns", ids.join(" "));
@@ -190,7 +189,7 @@ function onNodeAdded(target) {
 			// elem is the Add line comment button.
 			// nextElementSibling is the actual code.
 			// Reorder children using aria-owns.
-			makeElementOwn(elem.parentNode, [elem, elem.nextElementSibling]);
+			makeElementOwn(elem.parentNode, [elem.nextElementSibling, elem]);
 		}
 		// Make sure diff tables never get treated as a layout table.
 		for (elem of target.querySelectorAll(".diff-table"))

--- a/GitHubA11yFixes.user.js
+++ b/GitHubA11yFixes.user.js
@@ -62,7 +62,7 @@ function doGlobal(target){
 	var elem;
 	// Site-wide stuff.
 	// Checkable menu items; e.g. in watch and labels pop-ups.
-	if (target.classList.contains("select-menu-item")) {
+	if (target.classList && target.classList.contains("select-menu-item")) {
 		target.setAttribute("role", "menuitemcheckbox");
 		onSelectMenuItemChanged(target);
 	} else {
@@ -105,6 +105,7 @@ function doGlobal(target){
 		elem.removeAttribute("aria-label");
 	}
 	// Dropdowns; e.g. for "Add your reaction".
+	
 	if (target.classList && target.classList.contains("dropdown"))
 		onDropdownChanged(target);
 	else {
@@ -236,6 +237,5 @@ var observer = new MutationObserver(function(mutations) {
 });
 observer.observe(document, {childList: true, attributes: true,
 	subtree: true, attributeFilter: ["class"]});
-
 onNodeAdded(document);
 doGlobal(document);

--- a/readme.md
+++ b/readme.md
@@ -37,6 +37,7 @@ It does the following:
  - Commit group headers in commit listings
  - The commit title for single commits
  - The header for each changed file in pull requests and commits
+ - Each notification, and repo in the notifications list.
 - Ensures that various data tables aren't treated as layout tables, including:
  - The file content when viewing a single file
  - File listings
@@ -45,6 +46,7 @@ It does the following:
 - When there are lines of code which can be commented on (e.g. a pull request or commit), puts the comment buttons after (rather than before) the code.
 - Makes the state of checkable menu items accessible; e.g. in the watch and labels pop-ups.
 - Marks "Add your reaction" buttons as having a pop-up, focuses the first reaction when the add button is pressed and makes the labels of the reaction buttons less verbose.
+- Places the notification type indicator graphic after the notification link for ease of reading.
 
 ### Kill Windowless Flash
 [Download Kill Windowless Flash](https://github.com/nvaccess/axSGrease/raw/master/KillWindowlessFlash.user.js)

--- a/readme.md
+++ b/readme.md
@@ -37,7 +37,7 @@ It does the following:
  - Commit group headers in commit listings
  - The commit title for single commits
  - The header for each changed file in pull requests and commits
- - Each notification, and repo in the notifications list.
+ - Each notification and repo in the notifications list.
 - Ensures that various data tables aren't treated as layout tables, including:
  - The file content when viewing a single file
  - File listings


### PR DESCRIPTION
Make the github notifications accessible. this adds support by making every repo an h2 instead of an h3, so that each notification can be an h3. Further, it moves the issue graphic after the link, so the link is the first thing that comes up as a notification. A new helper "makeElementOwn" is added to make aria-ownsing something super easy.