### PR TITLE
Make PR filenames headings and label the file contents

### DIFF
--- a/GitHubA11yFixes.user.js
+++ b/GitHubA11yFixes.user.js
@@ -2,10 +2,10 @@
 // @name           GitHub Accessibility Fixes
 // @namespace      http://axSgrease.nvaccess.org/
 // @description    Improves the accessibility of GitHub.
-// @author         James Teh <jteh@mozilla.com>
-// @copyright 2019-2024 Mozilla Corporation, Derek Riemer
+// @author         James Teh <jteh@mozilla.com>, Sascha Cowley <sascha@nvaccess.org>
+// @copyright 2019-2024 Mozilla Corporation, Derek Riemer, Sascha Cowley
 // @license Mozilla Public License version 2.0
-// @version        2024.2
+// @version        2024.3
 // @include https://github.com/*
 // ==/UserScript==
 
@@ -163,6 +163,27 @@ const DYNAMIC_TWEAKS = [
 	// Remove headings from folder and file lists.
 	{selector: 'table[aria-labelledby=folders-and-files] :is(h2, h3)',
 		tweak: makePresentational},
+	// Make file viewer filenames headings, and the first item in the file viewer.
+	{selector: '.file-header .file-info .Truncate:has(.Link--primary)',
+		tweak: el => {
+			makeHeading(el, 2)
+			let headerRow = el.parentElement
+			let children = Array.from(headerRow.children)
+			// Filename is the last child of .file-info, make it the first
+			children.unshift(children.pop())
+			if (headerRow) {
+				makeElementOwn(headerRow, children);
+			}
+		}},
+	// Label diffs and the like with their filename.
+	{selector: '.file',
+		tweak: el => {
+			label = el.querySelector(".Link--primary")
+			file = el.querySelector(".js-file-content")
+			if (label && file) {
+				makeRegion(file, label.textContent)
+			}
+		}},
 ];
 
 /*** Lights, camera, action! ***/

--- a/GitHubA11yFixes.user.js
+++ b/GitHubA11yFixes.user.js
@@ -171,11 +171,11 @@ const DYNAMIC_TWEAKS = [
 	// Make file viewer filenames headings, and the first item in the file viewer.
 	{selector: '.file-header .file-info .Truncate:has(.Link--primary)',
 		tweak: el => {
-			makeHeading(el, 2)
-			let headerRow = el.parentElement
-			let children = Array.from(headerRow.children)
+			makeHeading(el, 2);
+			const headerRow = el.parentElement;
+			const children = Array.from(headerRow.children);
 			// Filename is the last child of .file-info, make it the first
-			children.unshift(children.pop())
+			children.unshift(children.pop());
 			if (headerRow) {
 				makeElementOwn(headerRow, children);
 			}
@@ -183,10 +183,10 @@ const DYNAMIC_TWEAKS = [
 	// Label diffs and the like with their filename.
 	{selector: '.file',
 		tweak: el => {
-			label = el.querySelector(".Link--primary")
-			file = el.querySelector(".js-file-content")
+			const label = el.querySelector(".Link--primary");
+			const file = el.querySelector(".js-file-content");
 			if (label && file) {
-				makeRegion(file, label.textContent)
+				makeRegion(file, label.textContent);
 			}
 		}},
 ];


### PR DESCRIPTION
- Makes the filenames in diff viewers level 2 headings.
- Moves the filename first, rather than after a bunch of controls for that file.
- Makes the file contents a region labelled by the filename. Useful when navigating by table rather than by heading.